### PR TITLE
fix 'cast' referenced before assignment

### DIFF
--- a/zap2xml.py
+++ b/zap2xml.py
@@ -1354,6 +1354,7 @@ def printProgrammes(fh):
                 live = ""
                 hd = ""
                 cc = ""
+                cast = ""
                 bullet = u" \u2022 "
                 if "originalAirDate" in programs[p]:
                     origdate = enc(convDateLocal(programs[p]["originalAirDate"]))


### PR DESCRIPTION
i had this error using -X option when testing
